### PR TITLE
Refactored generateRpcUrl out of protect button

### DIFF
--- a/protect/src/button.tsx
+++ b/protect/src/button.tsx
@@ -32,22 +32,20 @@ export interface ProtectButtonOptions extends PropsWithChildren {
   builders?: Array<string>,
 }
 
-/**
- * Button that connects Metamask to Flashbots Protect when it's clicked.
- */
-const FlashbotsProtectButton: FunctionComponent<ProtectButtonOptions> = ({
-  addChain,
+export const generateRpcUrl = ({
+  chainIdActual,
   hints,
   bundleId,
-  chainId,
-  children,
-  builders,
+  builders
+}: {
+  chainIdActual?: number;
+  hints?: HintPreferences;
+  bundleId?: string;
+  builders?: string[];
 }) => {
-  const chainIdActual: number = chainId || 1
-  const protectUrl =
-    chainIdActual === 5 ? "https://rpc-goerli.flashbots.net" :
-      chainIdActual === 11155111 ? "https://rpc-sepolia.flashbots.net" :
-        "https://rpc.flashbots.net"
+  const protectUrl = chainIdActual === 5 ? "https://rpc-goerli.flashbots.net" :
+    chainIdActual === 11155111 ? "https://rpc-sepolia.flashbots.net" :
+      "https://rpc.flashbots.net"
   const rpcUrl = new URL(protectUrl)
 
   if (hints) {
@@ -68,6 +66,23 @@ const FlashbotsProtectButton: FunctionComponent<ProtectButtonOptions> = ({
       rpcUrl.searchParams.append("builder", builder)
     }
   }
+  return rpcUrl
+}
+
+
+/**
+ * Button that connects Metamask to Flashbots Protect when it's clicked.
+ */
+const FlashbotsProtectButton: FunctionComponent<ProtectButtonOptions> = ({
+  addChain,
+  hints,
+  bundleId,
+  chainId,
+  children,
+  builders,
+}) => {
+  const chainIdActual: number = chainId || 1
+  const rpcUrl = generateRpcUrl(chainIdActual, hints, bundleId, builders)
 
   const connectToProtect = async () => {
     const addChainParams = {

--- a/protect/src/button.tsx
+++ b/protect/src/button.tsx
@@ -33,18 +33,18 @@ export interface ProtectButtonOptions extends PropsWithChildren {
 }
 
 export const generateRpcUrl = ({
-  chainIdActual,
+  chainId,
   hints,
   bundleId,
   builders
 }: {
-  chainIdActual?: number;
+  chainId?: number;
   hints?: HintPreferences;
   bundleId?: string;
   builders?: string[];
 }) => {
-  const protectUrl = chainIdActual === 5 ? "https://rpc-goerli.flashbots.net" :
-    chainIdActual === 11155111 ? "https://rpc-sepolia.flashbots.net" :
+  const protectUrl = chainId === 5 ? "https://rpc-goerli.flashbots.net" :
+    chainId === 11155111 ? "https://rpc-sepolia.flashbots.net" :
       "https://rpc.flashbots.net"
   const rpcUrl = new URL(protectUrl)
 
@@ -82,7 +82,7 @@ const FlashbotsProtectButton: FunctionComponent<ProtectButtonOptions> = ({
   builders,
 }) => {
   const chainIdActual: number = chainId || 1
-  const rpcUrl = generateRpcUrl(chainIdActual, hints, bundleId, builders)
+  const rpcUrl = generateRpcUrl({ chainId: chainIdActual, hints, bundleId, builders });
 
   const connectToProtect = async () => {
     const addChainParams = {

--- a/protect/src/index.ts
+++ b/protect/src/index.ts
@@ -1,5 +1,5 @@
 import FlashbotsProtectButton from './button'
 
-export { HintPreferences, ProtectButtonOptions } from './button'
+export { HintPreferences, ProtectButtonOptions, generateRpcUrl } from './button'
 
 export default FlashbotsProtectButton


### PR DESCRIPTION
There is a need to display the RpcURL directly as text so the method that generates the URL needs to be exposed.
